### PR TITLE
Data URIs; GLB; accessor improvements

### DIFF
--- a/io_scene_gltf/__init__.py
+++ b/io_scene_gltf/__init__.py
@@ -55,7 +55,7 @@ class ImportGLTF(bpy.types.Operator, ImportHelper):
     def get_buffer_view(self, idx):
         buffer_view = self.root['bufferViews'][idx]
         buffer = self.get_buffer(buffer_view["buffer"])
-        byte_offset = buffer_view["byteOffset"]
+        byte_offset = buffer_view.get("byteOffset", 0)
         byte_length = buffer_view["byteLength"]
         result = buffer[byte_offset:byte_offset + byte_length]
         stride = buffer_view.get('byteStride', None)

--- a/io_scene_gltf/__init__.py
+++ b/io_scene_gltf/__init__.py
@@ -108,7 +108,7 @@ class ImportGLTF(bpy.types.Operator, ImportHelper):
 
     def create_material(self, idx):
         material = self.root['materials'][idx]
-        material_name = material['name']
+        material_name = material.get('name', 'Material')
 
         if material_name in self.materials:
             return self.materials[material_name]
@@ -223,8 +223,8 @@ class ImportGLTF(bpy.types.Operator, ImportHelper):
 
     def create_mesh(self, node, mesh):
 
-        me = bpy.data.meshes.new(mesh['name'])
-        ob = bpy.data.objects.new(node['name'], me)
+        me = bpy.data.meshes.new(mesh.get('name', 'Mesh'))
+        ob = bpy.data.objects.new(node.get('name', 'Node'), me)
 
         self.create_translation(ob, node)
 
@@ -261,7 +261,7 @@ class ImportGLTF(bpy.types.Operator, ImportHelper):
         if 'mesh' in node:
             ob = self.create_mesh(node, self.root['meshes'][node['mesh']])
         else:
-            ob = bpy.data.objects.new(node['name'], None)
+            ob = bpy.data.objects.new(node.get('name', 'Node'), None)
             self.create_translation(ob, node)
 
         ob.parent = parent


### PR DESCRIPTION
Implements support for buffers using data URIs and the GLB buffer (textures don't crash if you use these but I don't know how to get Blender to load an image from memory so the texture data isn't loaded). Accessors were improved; the main missing feature now is the `sparse` property. Also some properties which the spec doesn't require are no longer unconditionally accessed so the importer doesn't crash if eg. a node is missing a name.

Several sample models which didn't work work now (CesiumMan for example).