### PR TITLE
Fix keyerror on byteOffset

### DIFF
--- a/io_scene_gltf/__init__.py
+++ b/io_scene_gltf/__init__.py
@@ -49,7 +49,10 @@ class ImportGLTF(bpy.types.Operator, ImportHelper):
     def get_buffer_view(self, idx):
         buffer_view = self.root['bufferViews'][idx]
         buffer = self.get_buffer(buffer_view["buffer"])
-        byte_offset = buffer_view["byteOffset"]
+        if "byteOffset" in buffer_view:
+            byte_offset = buffer_view["byteOffset"]
+        else:
+            byte_offset = 0
         byte_length = buffer_view["byteLength"]
         result = buffer[byte_offset:byte_offset + byte_length]
         # print("view", len(result))


### PR DESCRIPTION
When importing the samples, there is now a crash due to a JSON keyerror.
This is because in the final glTF 2.0 specification, the byteOffset key
is optional on the first buffer view (when the offset is 0.)

This fix prevents the crash by first checking to make sure the key
exists, and if not just sets it to 0.